### PR TITLE
Raid role color

### DIFF
--- a/helpers/raids.js
+++ b/helpers/raids.js
@@ -179,7 +179,7 @@ async function addRaid(message) {
             m.guild.createRole({
               data: {
                 name: response.dataValues.idraids.toString(),
-                color: 'RANDOM',
+                color: 'DEFAULT',
                 mentionable: true
               }
             })

--- a/helpers/raids.js
+++ b/helpers/raids.js
@@ -179,6 +179,7 @@ async function addRaid(message) {
             m.guild.createRole({
               data: {
                 name: response.dataValues.idraids.toString(),
+                color: 'RANDOM',
                 mentionable: true
               }
             })


### PR DESCRIPTION
The color of a role is now the default, since for iOS users this came up as black (which was unreadable). 

The color can also be random (each raid will have a different color) which might be cool, but can also be unreadable for some people. Extra benefit is that people can easily differentiate between the different mentions.